### PR TITLE
Change: determine `chi` states automatically

### DIFF
--- a/examples/rho_3states.jl
+++ b/examples/rho_3states.jl
@@ -65,10 +65,7 @@ Plots.default(
 )
 #-
 #-
-default_optimization_savename_kwargs(
-    ignores=["chi", "prop_method", "use_threads"],
-    connector="#"
-);
+default_optimization_savename_kwargs(ignores=["prop_method", "use_threads"], connector="#");
 
 #jl using Test; println("")
 
@@ -301,7 +298,6 @@ const problem = ControlProblem(
     ),
     tlist=tlist,
     iter_stop=3000,
-    chi=QuantumControl.Functionals.chi_re!,
     J_T=QuantumControl.Functionals.J_T_re,
     check_convergence=res -> begin
         ((res.J_T < 1e-3) && (res.converged = true) && (res.message = "J_T < 10⁻³"))

--- a/examples/simple_state_to_state.jl
+++ b/examples/simple_state_to_state.jl
@@ -150,7 +150,6 @@ problem = ControlProblem(
     ),
     tlist=tlist,
     iter_stop=50,
-    chi=QuantumControl.Functionals.chi_ss!,
     J_T=QuantumControl.Functionals.J_T_ss,
     check_convergence=res -> begin
         ((res.J_T < 1e-3) && (res.converged = true) && (res.message = "J_T < 10⁻³"))
@@ -186,16 +185,14 @@ fig = plot_population(guess_dynamics[1, :], guess_dynamics[2, :], tlist)
 # that the intended state-to-state transfer $\ket{\Psi_{\init}} \rightarrow
 # \ket{\Psi_{\tgt}}$ is solved, via `optimize` routine.
 # It requires, besides the previously defined
-# `objectives`, information about the optimization functional $J_T$ (implicitly,
-# via `chi_constructor`, which calculates the states $\ket{\chi} =
-# \frac{J_T}{\bra{\Psi}}$).
+# `objectives`, information about the optimization functional $J_T$.
 
 opt_result, file = @optimize_or_load(
     datadir(),
     problem,
     method = :krotov,
     prefix = "TLSOCT",
-    savename_kwargs = Dict(:ignores => ["chi"], :connector => "#")
+    savename_kwargs = Dict(:connector => "#")
 );
 #-
 opt_result

--- a/examples/state_to_state_parametrizations.jl
+++ b/examples/state_to_state_parametrizations.jl
@@ -172,7 +172,6 @@ problem = ControlProblem(
     ),
     tlist=tlist,
     iter_stop=50,
-    chi=QuantumControl.Functionals.chi_ss!,
     J_T=QuantumControl.Functionals.J_T_ss,
     check_convergence=res -> begin
         ((res.J_T < 1e-3) && (res.converged = true) && (res.message = "J_T < 10⁻³"))
@@ -214,7 +213,6 @@ problem_tanhsq = ControlProblem(
     ),
     tlist=tlist,
     iter_stop=50,
-    chi=QuantumControl.Functionals.chi_ss!,
     J_T=QuantumControl.Functionals.J_T_ss,
     check_convergence=res -> begin
         ((res.J_T < 1e-3) && (res.converged = true) && (res.message = "J_T < 10⁻³"))
@@ -256,7 +254,6 @@ problem_logisticsq = ControlProblem(
     ),
     tlist=tlist,
     iter_stop=50,
-    chi=QuantumControl.Functionals.chi_ss!,
     J_T=QuantumControl.Functionals.J_T_ss,
     check_convergence=res -> begin
         ((res.J_T < 1e-3) && (res.converged = true) && (res.message = "J_T < 10⁻³"))
@@ -294,7 +291,6 @@ problem_tanh = ControlProblem(
     ),
     tlist=tlist,
     iter_stop=50,
-    chi=QuantumControl.Functionals.chi_ss!,
     J_T=QuantumControl.Functionals.J_T_ss,
     check_convergence=res -> begin
         ((res.J_T < 1e-3) && (res.converged = true) && (res.message = "J_T < 10⁻³"))


### PR DESCRIPTION
Use the `make_chi` routine to automatically set the appropriate `chi` routine from the chosen functional, or obtain it via automatic differentiation. This makes `chi` and optional parameter for the optimization (and one that will rarely, if ever, have to be set).

This implements "semi-automatic differentiation" for Krotov's method.