### PR TITLE
Fix: flush stdout in `print_table`

### DIFF
--- a/src/optimize.jl
+++ b/src/optimize.jl
@@ -315,4 +315,5 @@ function print_table(wrk, iteration, args...)
         print(lpad(str, w))
     end
     print("\n")
+    flush(stdout)
 end


### PR DESCRIPTION
This fixes the output of print_table during the optimization so that it works in Jupyter notebooks or when piping output to a file (e.g., on a cluster) by flushing stdout after each iteration.

Without this, nothing was being printed while the optimization was still running.
