### PR TITLE
Allow to give global pulse options

### DIFF
--- a/examples/perfect_entanglers.jl
+++ b/examples/perfect_entanglers.jl
@@ -302,16 +302,8 @@ J_T_PE(guess_states, objectives)
 
 problem = ControlProblem(
     objectives=objectives,
-    pulse_options=IdDict(
-        Ωre_guess => Dict(
-            :lambda_a => 10.0,
-            :update_shape => t -> flattop(t, T=400ns, t_rise=15ns, func=:blackman),
-        ),
-        Ωim_guess => Dict(
-            :lambda_a => 10.0,
-            :update_shape => t -> flattop(t, T=400ns, t_rise=15ns, func=:blackman),
-        ),
-    ),
+    lambda_a=10.0,
+    update_shape=(t -> flattop(t, T=400ns, t_rise=15ns, func=:blackman)),
     tlist=tlist,
     iter_stop=100,
     J_T=J_T_PE,

--- a/examples/rho_3states.jl
+++ b/examples/rho_3states.jl
@@ -282,18 +282,8 @@ const problem = ControlProblem(
     objectives=objectives,
     prop_method=:newton,
     use_threads=true,
-    pulse_options=IdDict(
-        Ωre => Dict(
-            :lambda_a => 1.0,
-            :update_shape =>
-                t -> QuantumControl.Shapes.flattop(t, T=T, t_rise=20ns, func=:blackman),
-        ),
-        Ωim => Dict(
-            :lambda_a => 1.0,
-            :update_shape =>
-                t -> QuantumControl.Shapes.flattop(t, T=T, t_rise=20ns, func=:blackman),
-        ),
-    ),
+    lambda_a=1.0,
+    update_shape=(t -> QuantumControl.Shapes.flattop(t, T=T, t_rise=20ns, func=:blackman)),
     tlist=tlist,
     iter_stop=3000,
     J_T=QuantumControl.Functionals.J_T_re,

--- a/examples/simple_state_to_state.jl
+++ b/examples/simple_state_to_state.jl
@@ -142,13 +142,8 @@ objectives = [Objective(initial_state=ket(0), generator=H, target_state=ket(1))]
 
 problem = ControlProblem(
     objectives=objectives,
-    pulse_options=IdDict(
-        ϵ => Dict(
-            :lambda_a => 5,
-            :update_shape =>
-                t -> QuantumControl.Shapes.flattop(t, T=5, t_rise=0.3, func=:blackman),
-        )
-    ),
+    lambda_a=5,
+    update_shape=(t -> QuantumControl.Shapes.flattop(t, T=5, t_rise=0.3, func=:blackman)),
     tlist=tlist,
     iter_stop=50,
     J_T=QuantumControl.Functionals.J_T_ss,

--- a/examples/state_to_state_parametrizations.jl
+++ b/examples/state_to_state_parametrizations.jl
@@ -184,12 +184,8 @@ plot_amplitude(a, tlist)
 #-
 problem = ControlProblem(
     objectives=substitute(objectives, IdDict(ϵ => a)),
-    pulse_options=IdDict(
-        a.control => Dict(
-            :lambda_a => 5,
-            :update_shape => t -> flattop(t, T=5, t_rise=0.3, func=:blackman),
-        )
-    ),
+    lambda_a=5,
+    update_shape=(t -> flattop(t, T=5, t_rise=0.3, func=:blackman)),
     tlist=tlist,
     iter_stop=50,
     J_T=QuantumControl.Functionals.J_T_ss,
@@ -233,12 +229,8 @@ a = ParametrizedAmplitude(
 
 problem_tanhsq = ControlProblem(
     objectives=substitute(objectives, IdDict(ϵ => a)),
-    pulse_options=IdDict(
-        a.control => Dict(
-            :lambda_a => 10,
-            :update_shape => t -> flattop(t, T=5, t_rise=0.3, func=:blackman),
-        )
-    ),
+    lambda_a=10,
+    update_shape=(t -> flattop(t, T=5, t_rise=0.3, func=:blackman)),
     tlist=tlist,
     iter_stop=50,
     J_T=QuantumControl.Functionals.J_T_ss,
@@ -283,12 +275,8 @@ a = ParametrizedAmplitude(
 
 problem_logisticsq = ControlProblem(
     objectives=substitute(objectives, IdDict(ϵ => a)),
-    pulse_options=IdDict(
-        a.control => Dict(
-            :lambda_a => 1,
-            :update_shape => t -> flattop(t, T=5, t_rise=0.3, func=:blackman),
-        )
-    ),
+    lambda_a=1,
+    update_shape=(t -> flattop(t, T=5, t_rise=0.3, func=:blackman)),
     tlist=tlist,
     iter_stop=50,
     J_T=QuantumControl.Functionals.J_T_ss,
@@ -329,12 +317,8 @@ a = ParametrizedAmplitude(
 
 problem_tanh = ControlProblem(
     objectives=substitute(objectives, IdDict(ϵ => a)),
-    pulse_options=IdDict(
-        a.control => Dict(
-            :lambda_a => 1,
-            :update_shape => t -> flattop(t, T=5, t_rise=0.3, func=:blackman),
-        )
-    ),
+    lambda_a=1,
+    update_shape=(t -> flattop(t, T=5, t_rise=0.3, func=:blackman)),
     tlist=tlist,
     iter_stop=50,
     J_T=QuantumControl.Functionals.J_T_ss,

--- a/src/optimize.jl
+++ b/src/optimize.jl
@@ -34,21 +34,28 @@ arguments used in the instantiation of `problem`.
 
 # Recommended problem keyword arguments
 
+* `lambda_a=1.0`: The inverse Krotov step width λ_a for every pulse.
+* `update_shape=(t->1.0)`: A function `S(t)` for the "update shape" that scales
+  the update for every pulse
+
+If different controls require different `lambda_a` or `update_shape`, a dict
+`pulse_options` must be given instead of a global `lambda_a` and
+`update_shape`, see below.
+
+# Optional problem keyword arguments
+
+The following keyword arguments are supported (with default values):
+
 * `pulse_options`: A dictionary that maps every control (as obtained by
   [`get_controls`](@ref
   QuantumControlBase.QuantumPropagators.Controls.get_controls) from the
   `problem.objectives`) to the following dict:
 
   - `:lambda_a`:  The value for inverse Krotov step width λₐ
-  - `:update_shape`: A function `t -> S(t)` for the "update shape" that scaled
+  - `:update_shape`: A function `S(t)` for the "update shape" that scales
     the Krotov pulse update.
 
-  If `pulse_options` is not given, ``λₐ = 1`` and ``S(t) ≡ 1`` are used for all
-  controls.
-
-# Optional problem keyword arguments
-
-The following keyword arguments are supported (with default values):
+  This overrides the global `lambda_a` and `update_shape` arguments.
 
 * `chi`: A function `chi!(χ, ϕ, objectives)` what receives a list `ϕ`
   of the forward propagated states and must set ``|χₖ⟩ = -∂J_T/∂⟨ϕₖ|``. If not


### PR DESCRIPTION
In most applications, the same value λₐ and the same update shape S(t) is used for all controls. Thus, we allow `lambda_a` and `update_shape` as direct parameters of `optimize`. The `pulse_options` dict is still available for when different controls need different parameters