### PR TITLE
Adapt to renaming of "objective" to "trajectory"

### DIFF
--- a/docs/src/refs.bib
+++ b/docs/src/refs.bib
@@ -258,3 +258,13 @@
     Pages = {150401},
     Volume = {120},
 }
+
+@article{GoerzNJP2014,
+    Author = {Goerz, Michael H. and Reich, Daniel M. and Koch, Christiane P.},
+    Title = {Optimal control theory for a unitary operation under dissipative evolution},
+    Journal = njp,
+    Year = {2014},
+    Doi = {10.1088/1367-2630/16/5/055012},
+    Pages = {055012},
+    Volume = {16},
+}

--- a/src/result.jl
+++ b/src/result.jl
@@ -24,7 +24,7 @@ mutable struct KrotovResult{STST}
 
     function KrotovResult(problem)
         tlist = problem.tlist
-        controls = get_controls(problem.objectives)
+        controls = get_controls(problem.trajectories)
         iter_start = get(problem.kwargs, :iter_start, 0)
         iter_stop = get(problem.kwargs, :iter_stop, 5000)
         iter = iter_start
@@ -34,7 +34,7 @@ mutable struct KrotovResult{STST}
         J_T = 0.0
         J_T_prev = 0.0
         optimized_controls = [copy(guess) for guess in guess_controls]
-        states = [similar(obj.initial_state) for obj in problem.objectives]
+        states = [similar(traj.initial_state) for traj in problem.trajectories]
         start_local_time = now()
         end_local_time = now()
         records = Vector{Tuple}()
@@ -68,7 +68,7 @@ Base.show(io::IO, ::MIME"text/plain", r::KrotovResult) = print(
 Krotov Optimization Result
 --------------------------
 - Started at $(r.start_local_time)
-- Number of objectives: $(length(r.states))
+- Number of trajectories: $(length(r.states))
 - Number of iterations: $(max(r.iter - r.iter_start, 0))
 - Value of functional: $(@sprintf("%.5e", r.J_T))
 - Reason for termination: $(r.message)

--- a/test/test_empty_optimization.jl
+++ b/test/test_empty_optimization.jl
@@ -1,6 +1,6 @@
 using Test
 using StableRNGs
-using QuantumControl: hamiltonian, optimize, ControlProblem, Objective
+using QuantumControl: hamiltonian, optimize, ControlProblem, Trajectory
 using QuantumControl.Controls: get_controls
 using QuantumControlTestUtils.RandomObjects: random_matrix, random_state_vector
 
@@ -13,21 +13,21 @@ using QuantumControlTestUtils.RandomObjects: random_matrix, random_state_vector
 
     N = 10
     H = random_matrix(N; rng)
-    objectives = [
-        Objective(;
-            initial_state=random_state_vector(N; rng),
-            generator=H,
+    trajectories = [
+        Trajectory(
+            random_state_vector(N; rng),
+            H;
             target_state=random_state_vector(N; rng)
         )
     ]
 
-    @test length(get_controls(objectives)) == 0
+    @test length(get_controls(trajectories)) == 0
 
     tlist = collect(range(0; length=1001, step=1.0))
 
-    problem = ControlProblem(; objectives, tlist, pulse_options=Dict())
+    problem = ControlProblem(trajectories, tlist; pulse_options=Dict())
 
-    msg = "no controls in objectives: cannot optimize"
+    msg = "no controls in trajectories: cannot optimize"
     @test_throws ErrorException(msg) optimize(problem; method=:krotov)
 
 end

--- a/test/test_pulse_optimization.jl
+++ b/test/test_pulse_optimization.jl
@@ -17,16 +17,16 @@ using QuantumControl.Functionals: J_T_re
     # call `discretize_on_midpoints` internally
     problem = dummy_control_problem(; pulses_as_controls=true)
     nt = length(problem.tlist)
-    guess_pulse = QuantumControl.Controls.get_controls(problem.objectives)[1]
+    guess_pulse = QuantumControl.Controls.get_controls(problem.trajectories)[1]
     @test length(guess_pulse) == nt - 1
-    guess_pulse_copy = copy(QuantumControl.Controls.get_controls(problem.objectives)[1])
+    guess_pulse_copy = copy(QuantumControl.Controls.get_controls(problem.trajectories)[1])
 
     # Optimizing this should not modify the original generator in any way
     res = optimize(problem; method=:krotov, J_T=J_T_re, iter_stop=2)
     opt_control = res.optimized_controls[1]
     @test length(opt_control) == nt  # optimized_controls are always *on* tlist
     opt_pulse = discretize_on_midpoints(opt_control, problem.tlist)
-    post_pulse = QuantumControl.Controls.get_controls(problem.objectives)[1]
+    post_pulse = QuantumControl.Controls.get_controls(problem.trajectories)[1]
 
     # * The generator should still have the exact same objects as controls
     @test guess_pulse ≡ post_pulse


### PR DESCRIPTION
As a side effect, it is now possible to pass propagation keyword arguments to the trajectory.

See https://github.com/JuliaQuantumControl/QuantumControlBase.jl/pull/72